### PR TITLE
nadpisanie sekcji contacts

### DIFF
--- a/src/partials/contacts.html
+++ b/src/partials/contacts.html
@@ -3,8 +3,8 @@
     <div class="container">
         <ul class="contacts__list">
             <li class="contacts__card">
-                <div class="contacts__heading">
-                    <p>cafe</p>
+                <div class="contacts__category">
+                    <strong class="contacts__category-text">cafe</strong>
                 </div>
                 <h3 class="contacts__box-title">Chicago</h3>
                 <p class="contacts__box-description">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
@@ -18,58 +18,63 @@
                         <p class="contacts__box-time">08:00 AM - 16:00 PM</p>
                     </div>
                 </div>
-                <address class="footer-adress">
-                    <div class="footer-adress__item">
-                        <a href="tel:+48111111111" class="footer-adress__link">+61(0) 383 766 284</a>
-                    </div>
-                    <div class="footer-adress__item">
-                        <a href="mailto:info@devstudio.com" class="footer-adress__link">noreply@envato.com</a>
-                    </div>
-                </address>
+                <div>
+                    <address class="contacts__adress">
+                        <a href="tel:+48111111111" class="contacts__adress_link">+61(0) 383 766 284</a>
+                        <a href="mailto:noreply@envato.com" class="contacts__adress_link">noreply@envato.com</a>
+                    </address>
+                </div>
             </li>
             <li class="contacts__card">
-                <div class="contacts__heading">
-                    <p>cafe</p>
+                <div class="contacts__category contacts__category--other">
+                    <strong class="contacts__category-text">foodtruck</strong>
                 </div>
-                <h3>Chicago</h3>
-                <p>Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
-                <div>
-                    ***
-                </div>
-                <p>Monday - Friday</p>
-                <p>06:00 AM - 10:00 PM</p>
-                <p>Saturday - Sunday</p>
-                <p>08:00 AM - 16:00 PM</p>
-                <div>
-                    ***
-                </div>
-                <address class="footer-adress">
-                    <div class="footer-adress__item">
-                        <a href="tel:+48111111111" class="footer-adress__link">+61(0) 383 766 284</a>
+                <h3 class="contacts__box-title">Los Angeles</h3>
+                <p class="contacts__box-description">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
+                <div class="contacts__box">
+                    <div class="contacts__box-item">
+                        <p class="contacts__box-title">Monday - Friday</p>
+                        <p class="contacts__box-time">06:00 AM - 10:00 PM</p>
                     </div>
-                    <div class="footer-adress__item">
-                        <a href="mailto:info@devstudio.com" class="footer-adress__link">noreply@envato.com</a>
+                    <div class="contacts__box-item">
+                        <p class="contacts__box-title">Saturday - Sunday</p>
+                        <p class="contacts__box-time">08:00 AM - 16:00 PM</p>
                     </div>
-                </address>
+                </div>
+                <div>
+                    <address class="contacts__adress">
+                        <a href="tel:+48111111111" class="contacts__adress_link">+61(0) 383 766 284</a>
+                        <a href="mailto:noreply@envato.com" class="contacts__adress_link">noreply@envato.com</a>
+                    </address>
+                </div>
             </li>
             <li class="contacts__card">
-                <div class="contacts__heading">
-                    <p>cafe</p>
+                <div class="contacts__category">
+                    <strong class="contacts__category-text">cafe</strong>
                 </div>
-                <h3>Chicago</h3>
-                <p>Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
+                <h3 class="contacts__box-title">New York</h3>
+                <p class="contacts__box-description">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
+                <div class="contacts__box">
+                    <div class="contacts__box-item">
+                        <p class="contacts__box-title">Monday - Friday</p>
+                        <p class="contacts__box-time">06:00 AM - 10:00 PM</p>
+                    </div>
+                    <div class="contacts__box-item">
+                        <p class="contacts__box-title">Saturday - Sunday</p>
+                        <p class="contacts__box-time">08:00 AM - 16:00 PM</p>
+                    </div>
+                </div>
                 <div>
-                    ***
+                    <address class="contacts__adress">
+                        <a href="tel:+48111111111" class="contacts__adress_link">+61(0) 383 766 284</a>
+                        <a href="mailto:noreply@envato.com" class="contacts__adress_link">noreply@envato.com</a>
+                    </address>
                 </div>
-                <p>Monday - Friday</p>
-                <p>06:00 AM - 10:00 PM</p>
-                <p>Saturday - Sunday</p>
-                <p>08:00 AM - 16:00 PM</p>
-                <div>
-                    ***
-                </div>
-                <address></address>
             </li>
         </ul>
+    </div>
+    <div class="buttons__container">
+        <button type="button" class="contacts__button-red">Our Locations &#62;</button>
+        <button type="button" class="contacts__button-white">Franchise &#62;</button>
     </div>
 </section>

--- a/src/sass/components/_contacts.scss
+++ b/src/sass/components/_contacts.scss
@@ -1,16 +1,33 @@
 /*do uzupełnienia wartości ze zmiennych znajdujące sie wewnątrz główneg projektu*/
 
 .contacts {
-    background-color: rgba(255, 245, 246, 1);
     padding-top: 50px;
     padding-bottom: 50px;
+
+    background-image: linear-gradient(to bottom,
+        rgb(255, 255, 255) 8%,
+        rgba(255, 245, 246, 1) 8%,
+        rgba(255, 245, 246, 1) 92%);
+        
+    @media screen and (min-width: 768px) {
+        background-image: linear-gradient(to bottom,
+            rgb(255, 255, 255) 18%,
+            rgba(255, 245, 246, 1) 18%,
+            rgba(255, 245, 246, 1) 82%);
+            }
+        
+    @media screen and (min-width: 1280px) {
+        background-image: linear-gradient(to bottom,
+            rgb(255, 255, 255) 22%,
+            rgba(255, 245, 246, 1) 22%,
+            rgba(255, 245, 246, 1) 78%);
+            }
 
 }
 
 .contacts__list {
     list-style: none;
     padding: 0;
-    transform: translateY(-166px);
     gap: 20px;
     display: flex;
     flex-wrap: wrap;
@@ -69,13 +86,11 @@
     text-transform: uppercase;
 }
 
-
 .contacts__box {
     margin: 0;
     padding: 32px 0 32px 0;
     border-bottom: 1px solid rgba(225, 225, 225, 1);
     border-top: 1px solid rgba(225, 225, 225, 1);
-
 }
 
 .contacts__box-item {
@@ -145,21 +160,18 @@
     flex-direction: column;
     align-items: center;
     gap: 10px;
-    transform: translateY(-112px);
-    /* -166px +54px = -112px */
+    margin-top: 54px;
 
     @media screen and (min-width: 768px) {
-        transform: translateY(-85px);
-        /* -166px +81px = -85px */
         flex-direction: row;
         justify-content: center;
+        margin-top: 81px;
     }
 
     @media screen and (min-width: 1280px) {
-        transform: translateY(-80px);
-        /* -166px +86px = -80px */
         flex-direction: row;
         justify-content: center;
+        margin-top: 86px;
     }
 }
 

--- a/src/sass/components/_contacts.scss
+++ b/src/sass/components/_contacts.scss
@@ -4,12 +4,13 @@
     background-color: rgba(255, 245, 246, 1);
     padding-top: 50px;
     padding-bottom: 50px;
+
 }
 
 .contacts__list {
     list-style: none;
     padding: 0;
-    margin: 0;
+    transform: translateY(-166px);
     gap: 20px;
     display: flex;
     flex-wrap: wrap;
@@ -21,6 +22,10 @@
         gap: 20px;
     }
 
+    @media screen and (min-width: 1280px) {
+        gap: 30px;
+    }
+
 }
 
 .contacts__card {
@@ -28,19 +33,19 @@
     background-color: white;
     box-shadow: 0px 8px 30px 0px rgba(212, 20, 67, 0.1);
     border-radius: 24px;
+    box-sizing: inherit;
 
     @media screen and (min-width: 768px) {
-        max-width: calc((100% - 40px) / 3);
+        width: calc((100% - 40px) / 3);
+    }
+
+    @media screen and (min-width: 1280px) {
+        width: calc((100% - 60px) / 3);
     }
 }
 
-.contacts__heading {
+.contacts__category {
     background-color: rgba(240, 209, 165, 1);
-    color: white;
-    font-size: 16px;
-    font-weight: 500;
-    line-height: 30px;
-    letter-spacing: 0.04em;
     width: 73px;
     height: 28px;
     border-radius: 6px;
@@ -48,11 +53,29 @@
     margin-bottom: 32px;
 }
 
+.contacts__category--other {
+    background-color: rgba(194, 226, 151, 1);
+    width: 138px;
+}
+
+.contacts__category-text {
+    font-family: DM Sans, sans-serif;
+    font-style: Medium;
+    color: white;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 30px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+
 .contacts__box {
     margin: 0;
     padding: 32px 0 32px 0;
     border-bottom: 1px solid rgba(225, 225, 225, 1);
     border-top: 1px solid rgba(225, 225, 225, 1);
+
 }
 
 .contacts__box-item {
@@ -60,8 +83,8 @@
 }
 
 .contacts__box-title {
-    font-family: DM Sans;
-    color: chartreuse;
+    font-family: DM Sans, sans-serif;
+    color: rgba(0, 0, 0, 1);
     font-size: 16px;
     font-weight: 500;
     line-height: 30px;
@@ -70,22 +93,137 @@
 }
 
 .contacts__box-description {
-    font-family: DM Sans;
+    font-family: DM Sans, sans-serif;
     font-size: 16px;
     font-weight: 500;
     line-height: 29px;
     letter-spacing: 0.04em;
-    color: rgb(220, 14, 59);
+    color: rgba(144, 126, 130, 1);
     margin: 0;
     padding: 10px 0 32px 0;
 }
 
 .contacts__box-time {
-    font-family: DM Sans;
+    font-family: DM Sans, sans-serif;
     font-size: 16px;
     font-weight: 500;
     line-height: 30px;
     letter-spacing: 0em;
     color: rgba(255, 165, 186, 1);
     margin: 0;
+}
+
+.contacts__adress {
+    display: flex;
+    flex-direction: column;
+    margin-top: 32px;
+}
+
+.contacts__adress_link {
+    font-family: DM Sans, sans-serif;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 29px;
+    letter-spacing: 0.04em;
+    color: rgba(144, 126, 130, 1);
+    font-style: normal;
+    text-decoration: none;
+    margin: 0;
+    transition-duration: 250ms;
+    transition-timing-function: cubic-bezier(0.075, 0.82, 0.165, 1);
+    color: rgba(144, 126, 130, 1);
+
+    &:hover,
+    &:focus {
+        color: rgba(212, 19, 66, 1);
+        cursor: pointer;
+    }
+}
+
+.buttons__container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    transform: translateY(-112px);
+    /* -166px +54px = -112px */
+
+    @media screen and (min-width: 768px) {
+        transform: translateY(-85px);
+        /* -166px +81px = -85px */
+        flex-direction: row;
+        justify-content: center;
+    }
+
+    @media screen and (min-width: 1280px) {
+        transform: translateY(-80px);
+        /* -166px +86px = -80px */
+        flex-direction: row;
+        justify-content: center;
+    }
+}
+
+
+.contacts__button-red {
+    background-color: rgba(212, 19, 66, 1);
+    color: rgba(255, 255, 255, 1);
+    font-family: DM Sans, sans-serif;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0em;
+    text-align: center;
+    border: 0;
+    border-radius: 22px;
+    height: 44px;
+    width: 161.45037841796875px;
+    border: 0;
+    transition: all 0.2s ease-out;
+
+    &:hover,
+    &:focus {
+        color: rgba(236, 235, 235, 1);
+        cursor: pointer;
+    }
+
+    @media screen and (min-width: 768px) {
+        height: 44px;
+        width: 191.45037841796875px;
+    }
+
+    @media screen and (min-width: 1280px) {
+        height: 44px;
+        width: 198;
+    }
+}
+
+.contacts__button-white {
+    background-color: rgba(255, 255, 255, 1);
+    color: rgba(212, 19, 66, 1);
+    font-family: DM Sans, sans-serif;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0em;
+    text-align: center;
+    border: 0;
+    border-radius: 22px;
+    height: 44px;
+    width: 161.45037841796875px;
+    border: 0;
+    transition: all 0.2s ease-out;
+
+    &:hover,
+    &:focus {
+        background: rgba(236, 235, 235, 1);
+        cursor: pointer;
+    }
+
+    @media screen and (min-width: 768px) {
+        min-height: 44px;
+        min-width: 191.45037841796875px;
+    }
+
+    @media screen and (min-width: 1280px) {
+        min-height: 44px;
+        min-width: 198;
+    }
 }


### PR DESCRIPTION
Poprzez nadpisanie 100% sekcji contacts oraz elementu contacts.scss wprowadzam szkielet sekcji. Wstępnie pokolorowanej i ułożonej. Kiedy zmiany zostaną zatwierdzone w kolejnym kroku, pokoloruje sekcje wedle kolorów ze zmiennych.
Zwracam uwagę na przesunięcie kart poprzez translateY . Dzięki temu uniosłem elementy zgodnie z makietą w FIGMA. Warunkuje to na sekcję, która znajduje się powyżej, gdyż zabiera trochę jej przestrzeni (dokładnie 166px) i analogicznie na sekcje poniżej zostawiając 166px do dyspozycji.

Przyciski, które znajdują się na dole sekcji contacts można by powiązać ze wspólną klasą buttons, gdyż większyść przycisków wygląda bardzo podobnie. Pozostawiam do decyzji lidera.

Tutaj można podejrzeć efekt w wersji live:
https://michaljurek.github.io/goit-markup-hw-08/portfolio.html

Pozdrawiam,
MJ