### PR TITLE
Dopieszczanie

### DIFF
--- a/src/sass/components/header-menu/_menu-background.scss
+++ b/src/sass/components/header-menu/_menu-background.scss
@@ -1,7 +1,6 @@
 .menu-background {
   // position: relative;
   height: 502px;
-  width: 100vw;
   background-color: getColor(pinky);
   overflow: hidden;
   transition: height $transition-time-timing;


### PR DESCRIPTION
Od mentora:
1. usuwam width: 100% z .menu-background. Rozszerza to aplikację horyzontalnie przez co pojawia się scroll-X. Widać do było u mnie i u Michała, naszego mentora.